### PR TITLE
Fix 2024 schedule times to Eastern timezone

### DIFF
--- a/src/pages/years/2024/index.astro
+++ b/src/pages/years/2024/index.astro
@@ -148,7 +148,7 @@ const photos = [
           <!-- Session 1 -->
           <div class="bg-[#F3F4F6] p-6 rounded-tl-[40px] rounded-tr-[10px] rounded-br-[40px] rounded-bl-[10px] flex flex-col md:flex-row gap-4">
             <div class="text-[#D33B32] font-bold whitespace-nowrap text-center md:text-left min-w-[140px]">
-              1:15 PM – 2:00 PM
+              9:15 AM – 10:00 AM
             </div>
             <div class="flex-1">
               <p class="font-semibold text-black">You Really Should Look at the Execution Plan</p>
@@ -160,7 +160,7 @@ const photos = [
           <!-- Session 2 -->
           <div class="bg-[#F3F4F6] p-6 rounded-tl-[40px] rounded-tr-[10px] rounded-br-[40px] rounded-bl-[10px] flex flex-col md:flex-row gap-4">
             <div class="text-[#D33B32] font-bold whitespace-nowrap text-center md:text-left min-w-[140px]">
-              2:15 PM – 3:00 PM
+              10:15 AM – 11:00 AM
             </div>
             <div class="flex-1">
               <p class="font-semibold text-black">Is Gen AI the killer app, or the final boss?</p>
@@ -172,7 +172,7 @@ const photos = [
           <!-- Session 3 -->
           <div class="bg-[#F3F4F6] p-6 rounded-tl-[40px] rounded-tr-[10px] rounded-br-[40px] rounded-bl-[10px] flex flex-col md:flex-row gap-4">
             <div class="text-[#D33B32] font-bold whitespace-nowrap text-center md:text-left min-w-[140px]">
-              3:15 PM – 4:00 PM
+              11:15 AM – 12:00 PM
             </div>
             <div class="flex-1">
               <p class="font-semibold text-black">How love lessons can land you a great job</p>
@@ -184,7 +184,7 @@ const photos = [
           <!-- Session 4 -->
           <div class="bg-[#F3F4F6] p-6 rounded-tl-[40px] rounded-tr-[10px] rounded-br-[40px] rounded-bl-[10px] flex flex-col md:flex-row gap-4">
             <div class="text-[#D33B32] font-bold whitespace-nowrap text-center md:text-left min-w-[140px]">
-              4:45 PM – 5:30 PM
+              12:45 PM – 1:30 PM
             </div>
             <div class="flex-1">
               <p class="font-semibold text-black">How to Lose an App in 60 seconds</p>
@@ -196,7 +196,7 @@ const photos = [
           <!-- Session 5 -->
           <div class="bg-[#F3F4F6] p-6 rounded-tl-[40px] rounded-tr-[10px] rounded-br-[40px] rounded-bl-[10px] flex flex-col md:flex-row gap-4">
             <div class="text-[#D33B32] font-bold whitespace-nowrap text-center md:text-left min-w-[140px]">
-              5:45 PM – 6:30 PM
+              1:45 PM – 2:30 PM
             </div>
             <div class="flex-1">
               <p class="font-semibold text-black">Empowering Efficiency at a National Lab through Low Code Solutions</p>
@@ -208,7 +208,7 @@ const photos = [
           <!-- Session 6 -->
           <div class="bg-[#F3F4F6] p-6 rounded-tl-[40px] rounded-tr-[10px] rounded-br-[40px] rounded-bl-[10px] flex flex-col md:flex-row gap-4">
             <div class="text-[#D33B32] font-bold whitespace-nowrap text-center md:text-left min-w-[140px]">
-              6:45 PM – 7:30 PM
+              2:45 PM – 3:30 PM
             </div>
             <div class="flex-1">
               <p class="font-semibold text-black">The Rise of AI Copilots</p>
@@ -220,7 +220,7 @@ const photos = [
           <!-- Session 7 -->
           <div class="bg-[#F3F4F6] p-6 rounded-tl-[40px] rounded-tr-[10px] rounded-br-[40px] rounded-bl-[10px] flex flex-col md:flex-row gap-4">
             <div class="text-[#D33B32] font-bold whitespace-nowrap text-center md:text-left min-w-[140px]">
-              7:45 PM – 8:30 PM
+              3:45 PM – 4:30 PM
             </div>
             <div class="flex-1">
               <p class="font-semibold text-black">The Day of Learning: Amplifying L&D</p>
@@ -232,7 +232,7 @@ const photos = [
           <!-- Session 8 -->
           <div class="bg-[#F3F4F6] p-6 rounded-tl-[40px] rounded-tr-[10px] rounded-br-[40px] rounded-bl-[10px] flex flex-col md:flex-row gap-4">
             <div class="text-[#D33B32] font-bold whitespace-nowrap text-center md:text-left min-w-[140px]">
-              8:45 PM – 9:30 PM
+              4:45 PM – 5:30 PM
             </div>
             <div class="flex-1">
               <p class="font-semibold text-black">Managing On-Call Chaos</p>


### PR DESCRIPTION
## Summary
Corrects the 2024 event schedule times from UTC to Eastern timezone. The schedule was displaying times 4 hours ahead of the actual event times.

## Changes
- Updated all 8 session times in `src/pages/years/2024/index.astro`
- Converted from UTC to Eastern (UTC-4) timezone
- Event now correctly shows starting at 9:15 AM instead of 1:15 PM

## Session Time Updates
- **Session 1** (Monica Morehouse): 1:15 PM → 9:15 AM
- **Session 2** (Travis Webb): 2:15 PM → 10:15 AM  
- **Session 3** (Chazona Baum): 3:15 PM → 11:15 AM
- **Session 4** (Michael Buckbee): 4:45 PM → 12:45 PM
- **Session 5** (Jenah Parman & Marla Schuchman): 5:45 PM → 1:45 PM
- **Session 6** (Ken Collins): 6:45 PM → 2:45 PM
- **Session 7** (Omar McNeil): 7:45 PM → 3:45 PM
- **Session 8** (Guillermo Fisher): 8:45 PM → 4:45 PM

## Test Plan
- [x] Built the site successfully with `yarn build`
- [x] Verified no TypeScript errors
- [x] Confirmed all session times now show in Eastern timezone
- [x] Event schedule now accurately reflects the May 31, 2024 event

🤖 Generated with [Claude Code](https://claude.com/claude-code)