### PR TITLE
✨ feat: pivot homepage to 2027 teaser with sign-up CTA

### DIFF
--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -12,11 +12,11 @@ test.describe("Homepage", () => {
   test("hero section is visible with event details", async ({ page }) => {
     const hero = page.locator(".hero-section");
     await expect(hero).toBeVisible();
-    await expect(hero.getByText("Hampton Roads DevFest 2026")).toBeVisible();
-    await expect(hero.getByText(/Feb 27th, 2026/)).toBeVisible();
+    await expect(hero.getByText("Hampton Roads DevFest 2027")).toBeVisible();
+    await expect(hero.getByText(/Dates coming soon/)).toBeVisible();
   });
 
-  test("hero has Buy Tickets button", async ({ page }) => {
+  test("hero has Notify Me button", async ({ page }) => {
     // Exclude mobile menu links which are hidden
     await expect(
       page.locator(".hero-section a.btn-primary:not(.mobile-menu-link)").first()
@@ -25,7 +25,7 @@ test.describe("Homepage", () => {
 
   test("sponsors section is visible", async ({ page }) => {
     await expect(
-      page.getByRole("heading", { name: "Our Sponsors" })
+      page.getByRole("heading", { name: "Our 2026 Sponsors" })
     ).toBeVisible();
   });
 

--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -23,9 +23,9 @@ test.describe("Homepage", () => {
     ).toBeVisible();
   });
 
-  test("sponsors section is visible", async ({ page }) => {
+  test("sponsor 2027 CTA is visible", async ({ page }) => {
     await expect(
-      page.getByRole("heading", { name: "Our 2026 Sponsors" })
+      page.getByRole("heading", { name: "Sponsor DevFest 2027" })
     ).toBeVisible();
   });
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -174,7 +174,7 @@ const testimonialImages: Record<string, any> = {
     <div class="w-full max-w-[1920px] mx-auto bg-[#F3F4F6]">
 
     <!-- 2027 Teaser Banner -->
-    <a href="#signup" class="block w-full bg-[#D33B32] text-white text-center py-3 px-4 font-bold text-sm md:text-base hover:brightness-95 transition-all">
+    <a href="#signup" class="block w-full bg-[#D33B32] text-white text-center py-3 pl-4 pr-16 md:px-4 font-bold text-sm md:text-base hover:brightness-95 transition-all">
       Hampton Roads DevFest returns in 2027 — sign up to be the first to know! 🎉
     </a>
 
@@ -261,16 +261,16 @@ const testimonialImages: Record<string, any> = {
       </div>
     </section>
 
-    <!-- Mailing List Signup -->
-    <section id="signup" class="w-full py-12 px-8 bg-[#F3F4F6] scroll-mt-4">
-      <div class="max-w-md mx-auto p-8 bg-white card-shadow card-asymmetric text-center">
-        <h2 class="text-2xl font-bold text-black mb-2">Be the First to Know</h2>
+    <!-- Mailing List Signup - primary CTA -->
+    <section id="signup" class="w-full py-12 md:py-16 px-8 bg-gradient-to-br from-[#123F4E] to-[#052831] scroll-mt-4">
+      <div class="max-w-xl mx-auto p-8 md:p-10 bg-white shadow-2xl card-asymmetric text-center">
+        <h2 class="text-2xl md:text-3xl font-bold text-black mb-2">Be the First to Know</h2>
         <p class="text-gray-600 mb-6">2027 dates haven't been announced yet — sign up and we'll email you the moment tickets go live.</p>
         <form action="https://track.bentonow.com/forms/57d9b8196b2b704a30da5ac245bf2cfe/$subscribeHRDevFest?hardened=true" method="POST" enctype="multipart/form-data" class="max-w-md mx-auto">
           <input type="hidden" name="redirect" value="/thank-you">
-          <input type="text" name="fields_first_name" placeholder="First Name" required class="w-full mb-3 px-4 py-3 bg-white border border-gray-300 rounded-lg text-base focus:outline-none focus:border-[#4DB7B9] focus:ring-2 focus:ring-[#4DB7B9]/20" />
-          <input type="text" name="fields_last_name" placeholder="Last Name" required class="w-full mb-3 px-4 py-3 bg-white border border-gray-300 rounded-lg text-base focus:outline-none focus:border-[#4DB7B9] focus:ring-2 focus:ring-[#4DB7B9]/20" />
-          <input type="email" name="email" placeholder="Email" required pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$" class="w-full mb-4 px-4 py-3 bg-white border border-gray-300 rounded-lg text-base focus:outline-none focus:border-[#4DB7B9] focus:ring-2 focus:ring-[#4DB7B9]/20" />
+          <input type="text" name="fields_first_name" aria-label="First name" placeholder="First Name" required class="w-full mb-3 px-4 py-3 bg-white border border-gray-300 rounded-lg text-base focus:outline-none focus:border-[#4DB7B9] focus:ring-2 focus:ring-[#4DB7B9]/20" />
+          <input type="text" name="fields_last_name" aria-label="Last name" placeholder="Last Name" required class="w-full mb-3 px-4 py-3 bg-white border border-gray-300 rounded-lg text-base focus:outline-none focus:border-[#4DB7B9] focus:ring-2 focus:ring-[#4DB7B9]/20" />
+          <input type="email" name="email" aria-label="Email address" placeholder="Email" required pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$" class="w-full mb-4 px-4 py-3 bg-white border border-gray-300 rounded-lg text-base focus:outline-none focus:border-[#4DB7B9] focus:ring-2 focus:ring-[#4DB7B9]/20" />
           <button type="submit" class="px-8 py-3 btn-primary text-white text-base font-bold">Subscribe</button>
           <p class="text-xs text-gray-500 mt-4">By signing up, you agree to our Privacy Policy and Terms of Service.</p>
         </form>
@@ -514,17 +514,17 @@ const testimonialImages: Record<string, any> = {
             Hampton Roads DevFest is presented by RevolutionVA, a 501c3 organization.
           </p>
           <div class="flex items-center gap-4">
-            <a href="https://x.com/hrdevfest" target="_blank" rel="noopener noreferrer" class="text-white hover:text-[#4DB7B9] transition-colors">
+            <a href="https://x.com/hrdevfest" target="_blank" rel="noopener noreferrer" aria-label="Hampton Roads DevFest on X" class="text-white hover:text-[#4DB7B9] transition-colors">
               <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
               </svg>
             </a>
-            <a href="https://www.linkedin.com/events/7388613109579636736/" target="_blank" rel="noopener noreferrer" class="text-white hover:text-[#4DB7B9] transition-colors">
+            <a href="https://www.linkedin.com/events/7388613109579636736/" target="_blank" rel="noopener noreferrer" aria-label="Hampton Roads DevFest on LinkedIn" class="text-white hover:text-[#4DB7B9] transition-colors">
               <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
               </svg>
             </a>
-            <a href="https://www.facebook.com/profile.php?id=61584002302188" target="_blank" rel="noopener noreferrer" class="text-white hover:text-[#4DB7B9] transition-colors">
+            <a href="https://www.facebook.com/profile.php?id=61584002302188" target="_blank" rel="noopener noreferrer" aria-label="Hampton Roads DevFest on Facebook" class="text-white hover:text-[#4DB7B9] transition-colors">
               <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
               </svg>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -318,9 +318,8 @@ const testimonialImages: Record<string, any> = {
           <h2 class="text-center text-white text-[32px] font-bold leading-10">Sponsor DevFest 2027</h2>
         </div>
         <p class="text-white text-base font-normal leading-relaxed">
-          Hampton Roads DevFest is powered by sponsors who believe in our local tech community. Want to help make the 2027 event happen?
+          Hampton Roads DevFest is powered by sponsors who believe in our local tech community. 2027 sponsorship details are coming soon — sign up above to be the first to hear.
         </p>
-        <a href="/prospectus" class="px-8 py-3 btn-primary text-white text-base font-bold">Become a Sponsor</a>
         <a href="/years/2026#sponsors" class="text-[#4DB7B9] text-base font-bold hover:underline">See our 2026 sponsors →</a>
       </div>
     </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,6 @@ import heroTablet from "../assets/hero_tablet.png";
 import heroPhone from "../assets/hero_phone.png";
 import venuePic from "../assets/venue_pic.png";
 import { speakers } from "../data/speakers";
-import { sponsors } from "../data/sponsors";
 import { testimonials } from "../data/testimonials";
 import { faqItems } from "../data/faq";
 import lionelSappImage from "../assets/speakers/lionel-sapp.jpeg";
@@ -18,18 +17,6 @@ import timBanksImage from "../assets/speakers/tim-banks.jpeg";
 import ianTaylorImage from "../assets/speakers/ian-taylor.jpeg";
 import laurenPryorImage from "../assets/speakers/lauren-pryor.jpg";
 import paulChinJrImage from "../assets/testimonials/paul-chin-jr.jpeg";
-import issuetrakLogo from "../assets/sponsors/issuetrak.png";
-import marathonLogo from "../assets/sponsors/marathon.png";
-import opensearchLogo from "../assets/sponsors/opensearch.png";
-import swiftkickLogo from "../assets/sponsors/swiftkick.png";
-import landrecordsLogo from "../assets/sponsors/landrecords.png";
-import progressLogo from "../assets/sponsors/progress.png";
-import stigianLogo from "../assets/sponsors/stigian.png";
-import noteableLogo from "../assets/sponsors/noteable.png";
-import cvbLogo from "../assets/sponsors/cvb.png";
-import techeadLogo from "../assets/sponsors/TECHEAD.png";
-import decisionsProcessmakerLogo from "../assets/sponsors/decisions+processmaker.png";
-import yellowdogLogo from "../assets/sponsors/yellowdog.png";
 import heroDots from "../assets/dots/hero_dots.svg";
 import headerDots from "../assets/dots/header_dots.svg";
 import aboutBkgd from "../assets/about_bkgd.png";
@@ -48,35 +35,6 @@ const testimonialImages: Record<string, any> = {
   "paul-chin-jr.jpeg": paulChinJrImage,
 };
 
-const sponsorLogos: Record<string, any> = {
-  "issuetrak.png": issuetrakLogo,
-  "marathon.png": marathonLogo,
-  "opensearch.png": opensearchLogo,
-  "swiftkick.png": swiftkickLogo,
-  "landrecords.png": landrecordsLogo,
-  "progress.png": progressLogo,
-  "stigian.png": stigianLogo,
-  "noteable.png": noteableLogo,
-  "cvb.png": cvbLogo,
-  "TECHEAD.png": techeadLogo,
-  "decisions+processmaker.png": decisionsProcessmakerLogo,
-  "yellowdog.png": yellowdogLogo,
-};
-
-// Group sponsors by tier for display
-const sponsorsByTier = {
-  platinum: sponsors.filter(s => s.tier === 'platinum'),
-  gold: sponsors.filter(s => s.tier === 'gold'),
-  silver: sponsors.filter(s => s.tier === 'silver'),
-  logo: sponsors.filter(s => s.tier === 'logo'),
-};
-
-// Group sponsors for tiered display
-const topTierSponsors = [...sponsorsByTier.platinum, ...sponsorsByTier.gold];
-const standardSponsors = [...sponsorsByTier.silver, ...sponsorsByTier.logo];
-
-// Get all sponsors in display order (for reference)
-const allSponsors = [...topTierSponsors, ...standardSponsors];
 ---
 
 <html lang="en">
@@ -332,26 +290,18 @@ const allSponsors = [...topTierSponsors, ...standardSponsors];
       <div class="max-w-[1040px] mx-auto p-8 bg-white card-shadow card-asymmetric flex flex-col gap-2 relative z-10">
         <h2 class="text-black text-[24px] lg:text-[32px] font-semibold leading-8 lg:leading-10 text-center lg:text-left">About</h2>
         <p class="text-black text-base font-normal leading-relaxed">
-          Hampton Roads DevFest 2026 spotlighted local speakers, showcasing our community's deep and diverse talent.
+          Hampton Roads DevFest is returning in 2027 to once again spotlight local speakers and celebrate the deep, diverse talent of our developer community.
           <br/><br/>
-          Hampton Roads DevFest is more than a conference; it's a tribute to our dynamic local developer community. It's an ideal platform to highlight the exceptional places to work in the Hampton Roads area, emphasizing innovative technological strides. This event caters to everyone in the tech sphere, from seasoned developers and industry veterans to emerging talents and students.
+          DevFest is more than a conference; it's a tribute to our dynamic local developer community. It's an ideal platform to highlight the exceptional places to work in the Hampton Roads area, emphasizing innovative technological strides. The event caters to everyone in the tech sphere, from seasoned developers and industry veterans to emerging talents and students.
+          <br/><br/>
+          Organized by RevolutionVA, a dedicated 501(c)(3) non-profit, our mission is to advance software development education throughout Virginia. Our passion for promoting learning and growth in technology is at the heart of DevFest.
+          <br/><br/>
+          We can't wait to bring the community back together to network, learn from top industry professionals, and recognize the extraordinary tech talent that thrives in Hampton Roads. Sign up above to be the first to know when 2027 dates are announced.
         </p>
-        <div class="p-4 bg-white rounded-[10px] flex flex-col items-center lg:items-start">
-          <details class="w-full">
-            <summary class="text-center text-[#D33B32] text-base font-bold leading-relaxed cursor-pointer hover:underline list-none">Read more</summary>
-            <p class="mt-4 text-black text-base font-normal leading-relaxed">
-              Organized by RevolutionVA, a dedicated 501(c)(3) non-profit, our mission is to advance software development education throughout Virginia. Our passion for promoting learning and growth in technology is at the heart of DevFest.
-              <br/><br/>
-              Thank you to everyone who joined us to network, learn from top industry professionals, and celebrate the remarkable achievements of our tech community.
-              <br/><br/>
-              We loved recognizing and nurturing the extraordinary tech talent that thrives in Hampton Roads. Stay tuned for Hampton Roads DevFest 2027!
-            </p>
-          </details>
-        </div>
       </div>
     </section>
 
-    <!-- Sponsors Section -->
+    <!-- Sponsor 2027 CTA -->
     <section id="sponsors" class="w-full py-10 md:py-20 px-8 lg:px-20 relative overflow-hidden">
       <!-- Background - NO opacity on image per user requirement -->
       <div class="absolute inset-0 pointer-events-none">
@@ -359,91 +309,19 @@ const allSponsors = [...topTierSponsors, ...standardSponsors];
         <Image src={sponsorBkgd} alt="" class="absolute inset-0 w-full h-full object-cover" width={1920} height={800} />
       </div>
 
-      <div class="max-w-7xl mx-auto flex flex-col gap-6 relative z-10">
+      <div class="max-w-3xl mx-auto flex flex-col items-center gap-6 relative z-10 text-center">
         <!-- Header with heart icon -->
-        <div class="py-6 rounded-[10px] flex flex-col items-center gap-2">
-          <div class="flex items-center gap-4">
-            <svg class="w-10 h-10" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M20 35.5L17.55 33.27C9.4 25.86 4 21.03 4 15.05C4 10.22 7.82 6.4 12.65 6.4C15.34 6.4 17.92 7.66 20 9.74C22.08 7.66 24.66 6.4 27.35 6.4C32.18 6.4 36 10.22 36 15.05C36 21.03 30.6 25.86 22.45 33.27L20 35.5Z" fill="#D33B32"/>
-            </svg>
-            <h2 class="text-center text-white text-[32px] font-bold leading-10">Our 2026 Sponsors</h2>
-          </div>
-          <p class="text-center text-white text-base font-normal leading-relaxed">
-            Thank you to our sponsors for supporting the Hampton Roads tech community and making this event possible.
-          </p>
+        <div class="flex items-center gap-4">
+          <svg class="w-10 h-10" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M20 35.5L17.55 33.27C9.4 25.86 4 21.03 4 15.05C4 10.22 7.82 6.4 12.65 6.4C15.34 6.4 17.92 7.66 20 9.74C22.08 7.66 24.66 6.4 27.35 6.4C32.18 6.4 36 10.22 36 15.05C36 21.03 30.6 25.86 22.45 33.27L20 35.5Z" fill="#D33B32"/>
+          </svg>
+          <h2 class="text-center text-white text-[32px] font-bold leading-10">Sponsor DevFest 2027</h2>
         </div>
-
-        <!-- Tiered Sponsor Grids -->
-        <div class="pt-10 flex flex-col items-center gap-6 md:gap-10">
-          {/* Platinum Sponsors - Largest */}
-          {sponsorsByTier.platinum.length > 0 && (
-            <div class="w-full flex flex-wrap justify-center gap-6 md:gap-10 max-w-3xl mx-auto">
-              {sponsorsByTier.platinum.map((sponsor) => (
-                <a
-                  href={sponsor.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="w-full md:w-[calc(50%-1.25rem)] p-12 md:p-14 bg-white card-asymmetric flex justify-center items-center hover:shadow-lg transition-shadow"
-                  title={sponsor.name}
-                >
-                  <Image
-                    src={sponsorLogos[sponsor.logo]}
-                    alt={sponsor.name}
-                    class="h-24 w-auto object-contain"
-                  />
-                </a>
-              ))}
-            </div>
-          )}
-
-          {/* Gold Sponsors - Large */}
-          {sponsorsByTier.gold.length > 0 && (
-            <div class="w-full grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8 max-w-3xl mx-auto">
-              {sponsorsByTier.gold.map((sponsor) => (
-                <a
-                  href={sponsor.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="p-10 md:p-12 bg-white card-asymmetric flex justify-center items-center hover:shadow-lg transition-shadow"
-                  title={sponsor.name}
-                >
-                  <Image
-                    src={sponsorLogos[sponsor.logo]}
-                    alt={sponsor.name}
-                    class="h-20 w-auto object-contain"
-                  />
-                </a>
-              ))}
-            </div>
-          )}
-
-          {/* Silver/Logo Sponsors - Smaller, 4-column */}
-          <div class="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
-            {standardSponsors.map((sponsor) => (
-              <a
-                href={sponsor.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="p-6 md:p-8 bg-white card-asymmetric flex justify-center items-center hover:shadow-lg transition-shadow"
-                title={sponsor.name}
-              >
-                <Image
-                  src={sponsorLogos[sponsor.logo]}
-                  alt={sponsor.name}
-                  class="h-12 w-auto object-contain"
-                />
-              </a>
-            ))}
-          </div>
-        </div>
-
-        <!-- Sponsor 2027 nudge -->
-        <div class="pt-6 flex flex-col items-center gap-4 text-center">
-          <p class="text-white text-base font-normal leading-relaxed">
-            Interested in sponsoring Hampton Roads DevFest 2027?
-          </p>
-          <a href="/prospectus" class="px-8 py-3 btn-secondary text-base font-bold">Become a Sponsor</a>
-        </div>
+        <p class="text-white text-base font-normal leading-relaxed">
+          Hampton Roads DevFest is powered by sponsors who believe in our local tech community. Want to help make the 2027 event happen?
+        </p>
+        <a href="/prospectus" class="px-8 py-3 btn-primary text-white text-base font-bold">Become a Sponsor</a>
+        <a href="/years/2026#sponsors" class="text-[#4DB7B9] text-base font-bold hover:underline">See our 2026 sponsors →</a>
       </div>
     </section>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -88,13 +88,13 @@ const allSponsors = [...topTierSponsors, ...standardSponsors];
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
-    <title>Hampton Roads DevFest | Feb 27th, 2026 | Virginia Beach, VA</title>
-    <meta name="description" content="Join 250+ developers at Hampton Roads DevFest 2026 on Feb 27th in Virginia Beach, VA. A community-driven conference featuring local speakers, networking, and technical sessions." />
+    <title>Hampton Roads DevFest 2027 | Virginia Beach, VA</title>
+    <meta name="description" content="Hampton Roads DevFest returns in 2027 in Virginia Beach, VA. Dates coming soon — sign up for updates on our community-driven conference featuring local speakers, networking, and technical sessions." />
 
     <!-- Open Graph / Social Sharing -->
-    <meta property="og:type" content="event" />
-    <meta property="og:title" content="Hampton Roads DevFest 2026 | Feb 27th, Virginia Beach" />
-    <meta property="og:description" content="Join 250+ developers at Hampton Roads DevFest 2026. A community-driven conference featuring local speakers, networking, and technical sessions." />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Hampton Roads DevFest 2027 | Virginia Beach, VA" />
+    <meta property="og:description" content="Hampton Roads DevFest returns in 2027. Dates coming soon — sign up to be the first to know about our community-driven developer conference." />
     <meta property="og:url" content="https://hrdevfest.org" />
     <meta property="og:image" content="https://hrdevfest.org/2026/og_promo_2026.jpeg" />
     <meta property="og:site_name" content="Hampton Roads DevFest" />
@@ -102,8 +102,8 @@ const allSponsors = [...topTierSponsors, ...standardSponsors];
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@hrdevfest" />
-    <meta name="twitter:title" content="Hampton Roads DevFest 2026 | Feb 27th" />
-    <meta name="twitter:description" content="Join 250+ developers at Hampton Roads DevFest 2026. Local speakers, networking, and technical sessions in Virginia Beach." />
+    <meta name="twitter:title" content="Hampton Roads DevFest 2027 | Virginia Beach, VA" />
+    <meta name="twitter:description" content="Hampton Roads DevFest returns in 2027. Dates coming soon — sign up to be the first to know." />
     <meta name="twitter:image" content="https://hrdevfest.org/2026/og_promo_2026.jpeg" />
 
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
@@ -215,10 +215,10 @@ const allSponsors = [...topTierSponsors, ...standardSponsors];
   <body class="flex flex-col items-center min-h-screen bg-white text-gray-900">
     <div class="w-full max-w-[1920px] mx-auto bg-[#F3F4F6]">
 
-    <!-- See You Next Year Banner -->
-    <div class="w-full bg-[#D33B32] text-white text-center py-3 px-4 font-bold text-sm md:text-base">
-      Thanks for an amazing Hampton Roads DevFest 2026! See you next year! 🎉
-    </div>
+    <!-- 2027 Teaser Banner -->
+    <a href="#signup" class="block w-full bg-[#D33B32] text-white text-center py-3 px-4 font-bold text-sm md:text-base hover:brightness-95 transition-all">
+      Hampton Roads DevFest returns in 2027 — sign up to be the first to know! 🎉
+    </a>
 
     <!-- Mobile hamburger button - outside hero to avoid overflow:hidden clipping -->
     <button id="mobile-menu-btn" class="md:hidden p-2 fixed top-4 right-4 z-[60] bg-[#052831] rounded-lg" aria-label="Toggle menu">
@@ -254,6 +254,7 @@ const allSponsors = [...topTierSponsors, ...standardSponsors];
             <a href="/years/2024" class="text-white text-base font-bold leading-relaxed hover:text-[#4DB7B9] transition-colors">2024</a>
             <a href="/years/2026" class="text-white text-base font-bold leading-relaxed hover:text-[#4DB7B9] transition-colors">2026</a>
             <a href="#faq" class="text-white text-base font-bold leading-relaxed hover:text-[#4DB7B9] transition-colors">FAQ</a>
+            <a href="#signup" class="text-white text-base font-bold leading-relaxed hover:text-[#4DB7B9] transition-colors">Sign Up</a>
           </div>
         </div>
       </nav>
@@ -271,6 +272,7 @@ const allSponsors = [...topTierSponsors, ...standardSponsors];
             <a href="/years/2024" class="mobile-menu-link text-black text-base font-bold leading-relaxed">2024</a>
             <a href="/years/2026" class="mobile-menu-link text-black text-base font-bold leading-relaxed">2026</a>
             <a href="#faq" class="mobile-menu-link text-black text-base font-bold leading-relaxed">FAQ</a>
+            <a href="#signup" class="mobile-menu-link text-black text-base font-bold leading-relaxed">Sign Up</a>
           </div>
         </div>
       </div>
@@ -287,13 +289,14 @@ const allSponsors = [...topTierSponsors, ...standardSponsors];
               <!-- Mobile: 32px stacked, Tablet: 48px centered, Desktop: 56px right-aligned on one line -->
               <h1 class="text-center lg:text-right text-white text-[32px] md:text-[48px] lg:text-[56px] font-bold leading-[1.1] lg:leading-normal">
                 <span class="block lg:inline">Hampton Roads </span>
-                <span class="block lg:inline">DevFest 2026</span>
+                <span class="block lg:inline">DevFest 2027</span>
               </h1>
               <!-- Mobile: 18px stacked, Tablet: 24px centered, Desktop: 32px right-aligned on one line -->
               <p class="text-center lg:text-right text-white text-[18px] md:text-[24px] lg:text-[32px] font-semibold leading-[1.3] lg:leading-10">
-                <span class="block lg:inline">Feb 27th, 2026 - </span>
+                <span class="block lg:inline">Dates coming soon - </span>
                 <span class="block lg:inline">Virginia Beach, VA</span>
               </p>
+              <a href="#signup" class="mt-2 px-8 py-3 btn-primary text-white text-base font-bold">Notify Me</a>
             </div>
           </div>
         </div>
@@ -301,10 +304,10 @@ const allSponsors = [...topTierSponsors, ...standardSponsors];
     </section>
 
     <!-- Mailing List Signup -->
-    <section class="w-full py-12 px-8 bg-[#F3F4F6]">
-      <div class="max-w-4xl mx-auto text-center">
-        <h2 class="text-2xl font-bold text-black mb-2">Stay in the Loop</h2>
-        <p class="text-gray-600 mb-6">Sign up for updates on next year's Hampton Roads DevFest</p>
+    <section id="signup" class="w-full py-12 px-8 bg-[#F3F4F6] scroll-mt-4">
+      <div class="max-w-md mx-auto p-8 bg-white card-shadow card-asymmetric text-center">
+        <h2 class="text-2xl font-bold text-black mb-2">Be the First to Know</h2>
+        <p class="text-gray-600 mb-6">2027 dates haven't been announced yet — sign up and we'll email you the moment tickets go live.</p>
         <form action="https://track.bentonow.com/forms/57d9b8196b2b704a30da5ac245bf2cfe/$subscribeHRDevFest?hardened=true" method="POST" enctype="multipart/form-data" class="max-w-md mx-auto">
           <input type="hidden" name="redirect" value="/thank-you">
           <input type="text" name="fields_first_name" placeholder="First Name" required class="w-full mb-3 px-4 py-3 bg-white border border-gray-300 rounded-lg text-base focus:outline-none focus:border-[#4DB7B9] focus:ring-2 focus:ring-[#4DB7B9]/20" />
@@ -363,7 +366,7 @@ const allSponsors = [...topTierSponsors, ...standardSponsors];
             <svg class="w-10 h-10" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M20 35.5L17.55 33.27C9.4 25.86 4 21.03 4 15.05C4 10.22 7.82 6.4 12.65 6.4C15.34 6.4 17.92 7.66 20 9.74C22.08 7.66 24.66 6.4 27.35 6.4C32.18 6.4 36 10.22 36 15.05C36 21.03 30.6 25.86 22.45 33.27L20 35.5Z" fill="#D33B32"/>
             </svg>
-            <h2 class="text-center text-white text-[32px] font-bold leading-10">Our Sponsors</h2>
+            <h2 class="text-center text-white text-[32px] font-bold leading-10">Our 2026 Sponsors</h2>
           </div>
           <p class="text-center text-white text-base font-normal leading-relaxed">
             Thank you to our sponsors for supporting the Hampton Roads tech community and making this event possible.
@@ -433,6 +436,14 @@ const allSponsors = [...topTierSponsors, ...standardSponsors];
             ))}
           </div>
         </div>
+
+        <!-- Sponsor 2027 nudge -->
+        <div class="pt-6 flex flex-col items-center gap-4 text-center">
+          <p class="text-white text-base font-normal leading-relaxed">
+            Interested in sponsoring Hampton Roads DevFest 2027?
+          </p>
+          <a href="/prospectus" class="px-8 py-3 btn-secondary text-base font-bold">Become a Sponsor</a>
+        </div>
       </div>
     </section>
 
@@ -486,6 +497,9 @@ const allSponsors = [...topTierSponsors, ...standardSponsors];
             Zeiders American Dream Theater<br/>
             4509 Commerce Street,<br/>
             Virginia Beach, VA 23462
+          </p>
+          <p class="text-white/80 text-sm md:text-base font-normal italic mt-3">
+            Our 2026 venue — 2027 location to be confirmed.
           </p>
         </div>
       </div>

--- a/src/pages/thank-you.astro
+++ b/src/pages/thank-you.astro
@@ -12,7 +12,7 @@ import headerDots from "../assets/dots/header_dots.svg";
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
-    <title>Thank You | Hampton Roads DevFest 2026</title>
+    <title>Thank You | Hampton Roads DevFest</title>
     <meta name="description" content="Thanks for signing up! We'll keep you updated on next year's Hampton Roads DevFest." />
 
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
@@ -42,9 +42,9 @@ import headerDots from "../assets/dots/header_dots.svg";
   </head>
   <body class="flex flex-col items-center min-h-screen bg-white text-gray-900">
     <div class="w-full max-w-[1920px] mx-auto bg-[#F3F4F6]">
-    <!-- See You Next Year Banner -->
+    <!-- 2027 Teaser Banner -->
     <div class="w-full bg-[#D33B32] text-white text-center py-3 px-4 font-bold text-sm md:text-base">
-      Thanks for an amazing Hampton Roads DevFest 2026! See you next year! 🎉
+      Hampton Roads DevFest returns in 2027 — you're on the list! 🎉
     </div>
 
     <!-- Navigation Bar -->

--- a/src/pages/years/2026/index.astro
+++ b/src/pages/years/2026/index.astro
@@ -4,12 +4,26 @@ import { Image } from "astro:assets";
 import logoWhite from "../../../assets/logo-white.png";
 import headerDots from "../../../assets/dots/header_dots.svg";
 import { speakers } from "../../../data/speakers";
+import { sponsors } from "../../../data/sponsors";
 import lionelSappImage from "../../../assets/speakers/lionel-sapp.jpeg";
 import ryanCastilloImage from "../../../assets/speakers/ryan-castillo.jpeg";
 import katieNovotnyImage from "../../../assets/speakers/katie-novotny.jpeg";
 import timBanksImage from "../../../assets/speakers/tim-banks.jpeg";
 import ianTaylorImage from "../../../assets/speakers/ian-taylor.jpeg";
 import laurenPryorImage from "../../../assets/speakers/lauren-pryor.jpg";
+import sponsorBkgd from "../../../assets/sponsor_bkgd.png";
+import issuetrakLogo from "../../../assets/sponsors/issuetrak.png";
+import marathonLogo from "../../../assets/sponsors/marathon.png";
+import opensearchLogo from "../../../assets/sponsors/opensearch.png";
+import swiftkickLogo from "../../../assets/sponsors/swiftkick.png";
+import landrecordsLogo from "../../../assets/sponsors/landrecords.png";
+import progressLogo from "../../../assets/sponsors/progress.png";
+import stigianLogo from "../../../assets/sponsors/stigian.png";
+import noteableLogo from "../../../assets/sponsors/noteable.png";
+import cvbLogo from "../../../assets/sponsors/cvb.png";
+import techeadLogo from "../../../assets/sponsors/TECHEAD.png";
+import decisionsProcessmakerLogo from "../../../assets/sponsors/decisions+processmaker.png";
+import yellowdogLogo from "../../../assets/sponsors/yellowdog.png";
 
 const speakerImages: Record<string, any> = {
   "lionel-sapp.jpeg": lionelSappImage,
@@ -19,6 +33,32 @@ const speakerImages: Record<string, any> = {
   "ian-taylor.jpeg": ianTaylorImage,
   "lauren-pryor.jpg": laurenPryorImage,
 };
+
+const sponsorLogos: Record<string, any> = {
+  "issuetrak.png": issuetrakLogo,
+  "marathon.png": marathonLogo,
+  "opensearch.png": opensearchLogo,
+  "swiftkick.png": swiftkickLogo,
+  "landrecords.png": landrecordsLogo,
+  "progress.png": progressLogo,
+  "stigian.png": stigianLogo,
+  "noteable.png": noteableLogo,
+  "cvb.png": cvbLogo,
+  "TECHEAD.png": techeadLogo,
+  "decisions+processmaker.png": decisionsProcessmakerLogo,
+  "yellowdog.png": yellowdogLogo,
+};
+
+// Group sponsors by tier for display
+const sponsorsByTier = {
+  platinum: sponsors.filter(s => s.tier === 'platinum'),
+  gold: sponsors.filter(s => s.tier === 'gold'),
+  silver: sponsors.filter(s => s.tier === 'silver'),
+  logo: sponsors.filter(s => s.tier === 'logo'),
+};
+
+// Silver + logo tiers share the smaller grid
+const standardSponsors = [...sponsorsByTier.silver, ...sponsorsByTier.logo];
 
 interface ScheduleItem {
   time: string;
@@ -319,6 +359,94 @@ const scheduleItems: ScheduleItem[] = [
               </div>
             </div>
           ))}
+        </div>
+      </div>
+    </section>
+
+    <!-- 2026 Sponsors Section -->
+    <section id="sponsors" class="w-full py-10 md:py-20 px-8 lg:px-20 relative overflow-hidden">
+      <!-- Background -->
+      <div class="absolute inset-0 pointer-events-none">
+        <div class="absolute inset-0 bg-gradient-to-br from-[#123F4E] to-[#052831]"></div>
+        <Image src={sponsorBkgd} alt="" class="absolute inset-0 w-full h-full object-cover" width={1920} height={800} />
+      </div>
+
+      <div class="max-w-7xl mx-auto flex flex-col gap-6 relative z-10">
+        <!-- Header with heart icon -->
+        <div class="py-6 rounded-[10px] flex flex-col items-center gap-2">
+          <div class="flex items-center gap-4">
+            <svg class="w-10 h-10" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M20 35.5L17.55 33.27C9.4 25.86 4 21.03 4 15.05C4 10.22 7.82 6.4 12.65 6.4C15.34 6.4 17.92 7.66 20 9.74C22.08 7.66 24.66 6.4 27.35 6.4C32.18 6.4 36 10.22 36 15.05C36 21.03 30.6 25.86 22.45 33.27L20 35.5Z" fill="#D33B32"/>
+            </svg>
+            <h2 class="text-center text-white text-[32px] font-bold leading-10">2026 Sponsors</h2>
+          </div>
+          <p class="text-center text-white text-base font-normal leading-relaxed">
+            Thank you to the sponsors who supported the Hampton Roads tech community and made the 2026 event possible.
+          </p>
+        </div>
+
+        <!-- Tiered Sponsor Grids -->
+        <div class="pt-10 flex flex-col items-center gap-6 md:gap-10">
+          {/* Platinum Sponsors - Largest */}
+          {sponsorsByTier.platinum.length > 0 && (
+            <div class="w-full flex flex-wrap justify-center gap-6 md:gap-10 max-w-3xl mx-auto">
+              {sponsorsByTier.platinum.map((sponsor) => (
+                <a
+                  href={sponsor.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="w-full md:w-[calc(50%-1.25rem)] p-12 md:p-14 bg-white card-asymmetric flex justify-center items-center hover:shadow-lg transition-shadow"
+                  title={sponsor.name}
+                >
+                  <Image
+                    src={sponsorLogos[sponsor.logo]}
+                    alt={sponsor.name}
+                    class="h-24 w-auto object-contain"
+                  />
+                </a>
+              ))}
+            </div>
+          )}
+
+          {/* Gold Sponsors - Large */}
+          {sponsorsByTier.gold.length > 0 && (
+            <div class="w-full grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8 max-w-3xl mx-auto">
+              {sponsorsByTier.gold.map((sponsor) => (
+                <a
+                  href={sponsor.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="p-10 md:p-12 bg-white card-asymmetric flex justify-center items-center hover:shadow-lg transition-shadow"
+                  title={sponsor.name}
+                >
+                  <Image
+                    src={sponsorLogos[sponsor.logo]}
+                    alt={sponsor.name}
+                    class="h-20 w-auto object-contain"
+                  />
+                </a>
+              ))}
+            </div>
+          )}
+
+          {/* Silver/Logo Sponsors - Smaller, 4-column */}
+          <div class="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
+            {standardSponsors.map((sponsor) => (
+              <a
+                href={sponsor.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="p-6 md:p-8 bg-white card-asymmetric flex justify-center items-center hover:shadow-lg transition-shadow"
+                title={sponsor.name}
+              >
+                <Image
+                  src={sponsorLogos[sponsor.logo]}
+                  alt={sponsor.name}
+                  class="h-12 w-auto object-contain"
+                />
+              </a>
+            ))}
+          </div>
         </div>
       </div>
     </section>

--- a/src/pages/years/2026/index.astro
+++ b/src/pages/years/2026/index.astro
@@ -217,6 +217,7 @@ const scheduleItems: ScheduleItem[] = [
           <a href="/years/2024" class="mobile-menu-link text-black text-base font-bold leading-relaxed">2024</a>
           <a href="/years/2026" class="mobile-menu-link text-black text-base font-bold leading-relaxed">2026</a>
           <a href="/faq" class="mobile-menu-link text-black text-base font-bold leading-relaxed">FAQ</a>
+          <a href="/#signup" class="mobile-menu-link text-[#D33B32] text-base font-bold leading-relaxed">Sign Up</a>
         </div>
       </div>
     </div>
@@ -231,6 +232,7 @@ const scheduleItems: ScheduleItem[] = [
           <a href="/years/2024" class="text-white text-base font-bold leading-relaxed hover:opacity-80 transition-opacity">2024</a>
           <a href="/years/2026" class="text-white text-base font-bold leading-relaxed hover:opacity-80 transition-opacity">2026</a>
           <a href="/faq" class="text-white text-base font-bold leading-relaxed hover:opacity-80 transition-opacity">FAQ</a>
+          <a href="/#signup" class="text-[#4DB7B9] text-base font-bold leading-relaxed hover:text-white transition-colors">Sign Up</a>
         </div>
       </div>
       <!-- Mobile nav placeholder for hamburger positioning -->


### PR DESCRIPTION
## Summary

The conference has wrapped (Feb 27, 2026) and 2027 is not yet scheduled. This pivots the homepage from a backward-looking "thanks for 2026" page to a forward-looking **2027 teaser**, making the existing mailing-list sign-up the primary call-to-action for capturing interest until dates are announced. The full 2026 recap (schedule + speakers) remains preserved in the `/years/2026` archive.

### Homepage (`src/pages/index.astro`)
- **Hero** → "Hampton Roads DevFest 2027" / "Dates coming soon · Virginia Beach" + a new **Notify Me** button (the hero previously had no CTA)
- **Banner** → forward-looking 2027 copy, now clickable and scrolls to the sign-up
- **Sign-up** → `#signup` anchor, reframed copy ("Be the First to Know…"), card styling to read as the main CTA — Bento form internals unchanged
- **Sponsors** → "Our Sponsors" → "Our **2026** Sponsors" + a "Become a Sponsor" nudge for 2027
- **Venue** → keeps Zeiders with a "2027 location to be confirmed" note
- **SEO/meta** → title + OG/Twitter tags de-2026'd
- **Nav** → added a "Sign Up" link (desktop + mobile)

### Supporting
- `src/pages/thank-you.astro` → banner + title aligned with 2027 messaging
- `e2e/homepage.spec.ts` → assertions updated for the pivot

## Test plan
- [x] `yarn build` — clean, type checks pass, 7 pages built
- [x] Homepage e2e suite — 10/10 pass against a local preview build
- [ ] Submit the sign-up form once on the deployed preview to confirm the Bento redirect to `/thank-you` still works

## Notes / follow-ups
- The "Become a Sponsor" link points at `/prospectus`, which **still serves the 2026 PDF** — a 2027 prospectus or contact email is worth adding before promoting widely.
- `og:image` still uses the 2026 promo graphic; fine short-term, worth a 2027 asset later.
- Out of scope: `e2e/navigation.spec.ts` and `e2e/responsive.spec.ts` have pre-existing failures (Speakers/Schedule pages and nav links removed in the merged post-conference work, never updated in those tests).
