### PR TITLE
✨ feat: add Google Analytics (GA4) tracking to all pages

### DIFF
--- a/src/components/GoogleAnalytics.astro
+++ b/src/components/GoogleAnalytics.astro
@@ -1,0 +1,16 @@
+---
+const GA_MEASUREMENT_ID = "G-404NY4WX8Z";
+---
+
+<!-- Google tag (gtag.js) -->
+<script
+  is:inline
+  async
+  src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}></script>
+<script is:inline>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-404NY4WX8Z');
+</script>

--- a/src/pages/code-of-conduct.astro
+++ b/src/pages/code-of-conduct.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import GoogleAnalytics from "../components/GoogleAnalytics.astro";
 import headerDots from "../assets/dots/header_dots.svg";
 ---
 
@@ -89,6 +90,8 @@ import headerDots from "../assets/dots/header_dots.svg";
         opacity: 0.8;
       }
     </style>
+
+    <GoogleAnalytics />
   </head>
   <body class="flex flex-col items-center min-h-screen bg-white text-gray-900">
     <div class="w-full max-w-[1920px] mx-auto bg-[#F3F4F6]">

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import GoogleAnalytics from "../components/GoogleAnalytics.astro";
 import headerDots from "../assets/dots/header_dots.svg";
 
 interface FAQItem {
@@ -206,6 +207,8 @@ const faqData: FAQCategory[] = [
         display: block;
       }
     </style>
+
+    <GoogleAnalytics />
   </head>
   <body class="flex flex-col items-center min-h-screen bg-white text-gray-900">
     <div class="w-full max-w-[1920px] mx-auto bg-[#F3F4F6]">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/global.css";
 import { Image } from "astro:assets";
+import GoogleAnalytics from "../components/GoogleAnalytics.astro";
 import logo from "../assets/logo.png";
 import logoWhite from "../assets/logo-white.png";
 import heroBkgd from "../assets/hero_bkgd.png";
@@ -169,6 +170,8 @@ const testimonialImages: Record<string, any> = {
       }
 
     </style>
+
+    <GoogleAnalytics />
   </head>
   <body class="flex flex-col items-center min-h-screen bg-white text-gray-900">
     <div class="w-full max-w-[1920px] mx-auto bg-[#F3F4F6]">

--- a/src/pages/thank-you.astro
+++ b/src/pages/thank-you.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import GoogleAnalytics from "../components/GoogleAnalytics.astro";
 import headerDots from "../assets/dots/header_dots.svg";
 ---
 
@@ -39,6 +40,8 @@ import headerDots from "../assets/dots/header_dots.svg";
         transform: scale(1.02);
       }
     </style>
+
+    <GoogleAnalytics />
   </head>
   <body class="flex flex-col items-center min-h-screen bg-white text-gray-900">
     <div class="w-full max-w-[1920px] mx-auto bg-[#F3F4F6]">

--- a/src/pages/years/2024/index.astro
+++ b/src/pages/years/2024/index.astro
@@ -1,6 +1,7 @@
 ---
 import "../../../styles/global.css";
 import { Image } from "astro:assets";
+import GoogleAnalytics from "../../../components/GoogleAnalytics.astro";
 import logoWhite from "../../../assets/logo-white.png";
 import header2024 from "../../../assets/header_2024.png";
 import headerDots from "../../../assets/dots/header_dots.svg";
@@ -33,6 +34,8 @@ const photos = [
     <meta name="generator" content={Astro.generator} />
     <title>Hampton Roads DevFest 2024 | Event Highlights</title>
     <script is:inline src="https://events.humanitix.com/scripts/widgets/popup.js" type="module"></script>
+
+    <GoogleAnalytics />
   </head>
   <body class="flex flex-col items-center min-h-screen bg-white text-gray-900">
     <div class="w-full max-w-[1920px] mx-auto bg-gray-100">

--- a/src/pages/years/2024/schedule.astro
+++ b/src/pages/years/2024/schedule.astro
@@ -1,6 +1,7 @@
 ---
 import "../../../styles/global.css";
 import { Image } from "astro:assets";
+import GoogleAnalytics from "../../../components/GoogleAnalytics.astro";
 import logo from "../../../assets/logo.png";
 import headerImage from "../../../assets/header-image.png";
 ---
@@ -17,6 +18,8 @@ import headerImage from "../../../assets/header-image.png";
     <title>Hampton Roads DevFest | May 31st, 2024 | Virginia Beach, VA</title>
 
     <script src="https://js.tito.io/v2/with/inline" async></script>
+
+    <GoogleAnalytics />
   </head>
   <body
     class="flex flex-col items-center justify-center min-h-screen bg-white text-gray-900"

--- a/src/pages/years/2026/index.astro
+++ b/src/pages/years/2026/index.astro
@@ -1,6 +1,7 @@
 ---
 import "../../../styles/global.css";
 import { Image } from "astro:assets";
+import GoogleAnalytics from "../../../components/GoogleAnalytics.astro";
 import logoWhite from "../../../assets/logo-white.png";
 import headerDots from "../../../assets/dots/header_dots.svg";
 import { speakers } from "../../../data/speakers";
@@ -193,6 +194,8 @@ const scheduleItems: ScheduleItem[] = [
         box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.10);
       }
     </style>
+
+    <GoogleAnalytics />
   </head>
   <body class="flex flex-col items-center min-h-screen bg-white text-gray-900">
     <div class="w-full max-w-[1920px] mx-auto bg-gray-100">


### PR DESCRIPTION
## Summary

Adds the Google Analytics 4 tag (`G-404NY4WX8Z`) to every page on the site.

This site has no shared layout — all 7 pages define their own `<head>` — so rather than pasting the snippet seven times, it is extracted into a reusable `GoogleAnalytics` component.

### Changes

**New:** `src/components/GoogleAnalytics.astro`

**Wired into** (import + `<GoogleAnalytics />` as the last element in `<head>`):

| Page | Route |
| --- | --- |
| `src/pages/index.astro` | `/` |
| `src/pages/faq.astro` | `/faq` |
| `src/pages/code-of-conduct.astro` | `/code-of-conduct` |
| `src/pages/thank-you.astro` | `/thank-you` |
| `src/pages/years/2024/index.astro` | `/years/2024` |
| `src/pages/years/2024/schedule.astro` | `/years/2024/schedule` |
| `src/pages/years/2026/index.astro` | `/years/2026` |

### Implementation note

Both script tags use Astro's `is:inline` directive so the snippet is emitted verbatim rather than bundled and scoped. This matters: without it, Astro wraps the inline script, which would keep `gtag` off the global scope. GA would still collect pageviews, but no other code on the page could call `gtag(...)` for custom events.

## Test plan

- [x] `yarn build` passes — 0 errors, 0 warnings (`astro check` + `astro build`)
- [x] Verified the tag renders into all 7 built HTML files in `dist/`
- [x] Verified the rendered markup matches the canonical GA snippet exactly, with `gtag` global
- [ ] After deploy: confirm realtime hits land in the GA property for `G-404NY4WX8Z`

🤖 Generated with [Claude Code](https://claude.com/claude-code)